### PR TITLE
feat: add ruff linter and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.9", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e . && pip install pytest
+      - run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.11"]
+        python-version: ["3.9", "3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ pip install -e .
 
 This installs the package in editable mode — any changes you make to the source code will take effect immediately without reinstalling.
 
+### Run tests:
+```
+pip install pytest
+pytest tests/ -v
+```
+
+### Run linter:
+```
+pip install ruff
+ruff check .
+```
+
 - To run a single player mode, type: (the single player mode is by default)
   ```
   tic_tac_toe --mode s

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+line-length = 120
+target-version = "py37"
+
+[lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E101", "W191", "E711", "E712", "E701", "E501"]
+
+[lint.per-file-ignores]
+"tests/*" = ["E402"]

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,8 +1,10 @@
-import sys
 import os
+import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from tic_tac_toe.tic_tac_toe import tic_tac_toe
+
 try:
     from unittest.mock import patch
 except ImportError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
-import sys
 import os
+import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from tic_tac_toe import utils
+
 try:
     from unittest.mock import patch
 except ImportError:

--- a/tic_tac_toe/tic_tac_toe.py
+++ b/tic_tac_toe/tic_tac_toe.py
@@ -4,22 +4,24 @@ Author: Husain Zafar
 Provides an elegant playing experience
 Uses Minimax algorithm
 Single and Two player modes
-Includes an option to display chances of winning per playable box, per move. 
+Includes an option to display chances of winning per playable box, per move.
 """
 
-from . import utils
-from . import constants
-import random
 import argparse
-from builtins import input
+import random
+
+from . import constants, utils
 
 
 def main(args=None):
 	parser = argparse.ArgumentParser(description=	'Play a game of Tic Tac Toe')
-	parser.add_argument('--mode', type=str, default = 's', choices = ['s', 't'], help = 'Mode: s(single player):default, t(two-player)')	
+	parser.add_argument(
+		'--mode', type=str, default='s', choices=['s', 't'],
+		help='Mode: s(single player):default, t(two-player)'
+	)
 	mode = parser.parse_args().mode
 	utils.clearScreen()
-	game = tic_tac_toe(mode)
+	tic_tac_toe(mode)
 	#549946 iterarions minimax
 	#upper limit 1+9*(1+8*(...(1+2*(1+1)...))
 
@@ -39,7 +41,7 @@ class tic_tac_toe:
 		the maximum value from the array is chosen else, the minimum value.
 		"""
 		[is_win, who_won] = utils.check_win(board, computerChar, playerChar)
-		if is_win == 2:			   
+		if is_win == 2:
 			return 0
 		if is_win == 1:
 			if who_won == computerChar:
@@ -70,7 +72,7 @@ class tic_tac_toe:
 		"""
 		keyboardIndexMapping = constants.keyboardIndexMapping
 		computerChar, playerChar, displayWinChance, whichPlayerFirst = utils.getSinglePlayerDetails()
-	
+
 		if whichPlayerFirst == 1:
 			utils.clearScreen()
 			utils.display_board(board)
@@ -116,7 +118,7 @@ class tic_tac_toe:
 				print ("You lost!!")
 			else:
 				print ("It's a draw!")
-	
+
 		if whichPlayerFirst == 2:
 			while utils.check_win(board, computerChar, playerChar)[0] == 0:
 				if utils.check_empty(board):
@@ -161,7 +163,7 @@ class tic_tac_toe:
 						if displayWinChance == 1:
 							utils.clearScreen()
 							utils.display_tutorial_board(board, tut)
-	
+
 			if utils.check_win(board, computerChar, playerChar)[0] == 1:
 				print ("You lost!!")
 			else:
@@ -179,7 +181,7 @@ class tic_tac_toe:
 			chance = playerOne
 		else:
 			chance = playerTwo
-	
+
 		while(utils.check_win(board, playerOneChar, playerTwoChar)[0] == 0):
 			utils.clearScreen()
 			utils.display_board(board)
@@ -187,7 +189,7 @@ class tic_tac_toe:
 			index = utils.get_move_input()
 			if index is None or index > 9 or index < 1:
 				utils.clearScreen()
-				continue		
+				continue
 			index = keyboardIndexMapping[index]
 			if(board[index] != '-'):
 				continue
@@ -208,6 +210,6 @@ class tic_tac_toe:
 				print(playerOne + " won!")
 			else:
 				print(playerTwo + " won!")
-	
+
 if __name__ == "__main__":
 	main()

--- a/tic_tac_toe/utils.py
+++ b/tic_tac_toe/utils.py
@@ -1,6 +1,7 @@
 import os
 import random
 
+
 def get_move_input():
 	"""
 	Prompts user for a move and validates that input is a digit between 1 and 9.
@@ -57,7 +58,7 @@ def display_tutorial_board(board, tut):
 
 def check_empty(board):
 	return board.count('-') == 9
-	
+
 def check_win(board, player1, player2):
 	"""
 	returns status of current board: 1-> won, 2-> draw, 0-> game undecided
@@ -126,7 +127,7 @@ def getTwoPlayerDetails():
 	playerOneChar = input("Enter character for "+ playerOne + " on board (x): ")
 	if playerOneChar == '':
 		playerOneChar = 'x'
-	playerTwoChar = input("Enter character for "+ playerTwo + " on board (o): ")	
+	playerTwoChar = input("Enter character for "+ playerTwo + " on board (o): ")
 	if playerTwoChar == '':
 		playerTwoChar = 'o'
 


### PR DESCRIPTION
## Summary
- Add ruff linter config (`ruff.toml`) with sensible defaults (closes #16)
- Add GitHub Actions CI workflow: lint + tests on Python 3.7/3.9/3.11
- Fix all existing lint violations (whitespace, import sorting, unused import/variable)
- Add test and linter instructions to README

## Test plan
- [x] `ruff check .` passes locally
- [x] `pytest tests/ -v` passes locally
- [x] GitHub Actions CI runs on this PR